### PR TITLE
Load after rules for NotSoFast

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1795,3 +1795,12 @@ plugins:
       - Delev
       - Invent
       - Relev
+  - name: 'NotSoFast-MainQuest.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2475/']
+    after:
+      - 'Book Covers Skyrim.esp'
+      - 'MLU.esp'
+    clean:
+      # version 1.6
+      - crc: 0x70426EF7
+        util: SSEEdit v3.2.1


### PR DESCRIPTION
- Load after Morrowloot ultimate & book covers.
- Clean plugin info.